### PR TITLE
fix(cli, logs): improve log command reliability and add get_entry

### DIFF
--- a/ttx/time_entries.py
+++ b/ttx/time_entries.py
@@ -472,3 +472,15 @@ def reassign_entry(entry_id: int, new_task_id: int, db_path: Path) -> bool:
             raise ValueError(f"task {new_task_id} not found")
         cur = conn.execute("UPDATE time_entries SET task_id=? WHERE id=?", (new_task_id, entry_id))
         return cur.rowcount > 0
+
+def get_entry(entry_id: int, db_path: Path):
+    """
+    Return a single time entry by id.
+    Shape: (id, task_id, start, end, note)
+    """
+    with connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT id, task_id, start, end, note FROM time_entries WHERE id = ?",
+            (entry_id,),
+        ).fetchone()
+        return row


### PR DESCRIPTION
- Standardize `db_path` keyword usage across log commands (`edit`, `rm`, `move`, `split`, `trim`)
- Improve error handling: confirm entry existence with `get_entry` when low-level functions return False/None
- Add `time_entries.get_entry` for consistent lookup of single entries
- Ensure log editing and trimming commands behave correctly and give clear feedback